### PR TITLE
Encode the percent sign in url

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,7 +21,7 @@ const getBadge = report => {
   const coverage = report.total.statements.pct
   const colour = getColour(coverage)
 
-  return `https://img.shields.io/badge/Coverage-${coverage}%-${colour}.svg`
+  return `https://img.shields.io/badge/Coverage-${coverage}${encodeURI('%')}-${colour}.svg`
 }
 
 const download = (url, cb) => {


### PR DESCRIPTION
Noticed this was returning a 400 because the percent sign is not encoded. This should fix the request.