### PR TITLE
feat: add option to add a logo to the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@
 Creates a code coverage badge like the following:
 
 ![Coverage badge][coverage-badge]
+![Jest Coverage badge][jest-coverage-badge]
 
 Currently just reads from Istanbul's JSON summary reporter and downloads a badge from https://shields.io/. Don't expect too much! Send a PR if you need configuration etc.
 
 [coverage-badge]: https://img.shields.io/badge/Coverage-100%25-brightgreen.svg
+[jest-coverage-badge]: https://img.shields.io/badge/Coverage-100%25-brightgreen.svg?logo=jest
 
 ## Usage
 
@@ -49,6 +51,10 @@ Writes the coverage badge to the given path (relative to project root). Defaults
 ### `--report-path <path>`
 
 Path to a coverage report file. Defaults to `./coverage/coverage-summary.json`.
+
+### `--logo <logo-string>`
+
+A string defining a logo usable by https://shields.io/. Their documentation has details on using logos. No default.
 
 ## Prior work
 

--- a/cli.js
+++ b/cli.js
@@ -15,7 +15,7 @@ const getColour = (coverage) => {
   return 'brightgreen'
 }
 
-const getBadge = (report) => {
+const getBadge = (report, logo) => {
   if (!(report && report.total && report.total.statements)) {
     throw new Error('malformed coverage report')
   }
@@ -23,9 +23,15 @@ const getBadge = (report) => {
   const coverage = report.total.statements.pct
   const colour = getColour(coverage)
 
-  return `https://img.shields.io/badge/Coverage-${coverage}${encodeURI(
+  let badgeUrl = `https://img.shields.io/badge/Coverage-${coverage}${encodeURI(
     '%'
   )}-${colour}.svg`
+
+  if (logo) {
+    badgeUrl += `?logo=${logo}`
+  }
+
+  return badgeUrl
 }
 
 const download = (url, cb) => {
@@ -42,6 +48,7 @@ const options = {
     outputPath: 'output-path',
   },
   boolean: 'help',
+  logo: 'string',
   default: {
     'output-path': './coverage/badge.svg',
     'report-path': './coverage/coverage-summary.json',
@@ -53,17 +60,19 @@ const { _, help, ...params } = mri(args, options) // eslint-disable-line no-unus
 
 if (help) {
   console.log(
-    `usage: ${basename(filename)} [-h,--help] [--report-path] [--output-path]`
+    `usage: ${basename(
+      filename
+    )} [-h,--help] [--report-path] [--output-path] [--logo]`
   )
   process.exit()
 }
 
-const { outputPath, 'report-path': reportPath } = params
+const { outputPath, 'report-path': reportPath, logo } = params
 
 readFile(reportPath, 'utf8', (err, res) => {
   if (err) throw err
   const report = JSON.parse(res)
-  const url = getBadge(report)
+  const url = getBadge(report, logo)
   download(url, (err, res) => {
     if (err) throw err
     writeFile(outputPath, res, 'utf8', (err) => {

--- a/test.js
+++ b/test.js
@@ -33,8 +33,16 @@ const test = async () => {
   assert.ok(badge.includes('90%'))
 }
 
+const logoTest = async () => {
+  await execP('./cli.js --logo jest')
+  const buffer = await readFile('./coverage/badge.svg')
+  const badge = buffer.toString()
+  assert.ok(badge.includes('<image'))
+}
+
 setup()
   .then(test)
+  .then(logoTest)
   .then(teardown)
   .catch((error) => {
     console.error(error)

--- a/test.js
+++ b/test.js
@@ -31,6 +31,7 @@ const test = async () => {
   const buffer = await readFile('./coverage/badge.svg')
   const badge = buffer.toString()
   assert.ok(badge.includes('90%'))
+  assert.ok(!badge.includes('<image'))
 }
 
 const logoTest = async () => {


### PR DESCRIPTION
## Description

I added an additional optional argument `logo`.
If this argument is set, it will be appended to the generated shields.io link, so that this package now supports badges with logos.

## How has this been tested?

I added a test to confirm that an `<image` tag is added to the generated badge if logo is set.
I updated the original test to confirm that the `<image` tag is _not_ added if logo is not set.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have ran `npm run lint` and everything passes
- [x] I have ran `npm run test` and everything passes
~- [ ] I have ran `npm run build` and everything built~ **There is no build command**
- [x] My code follows the code style of this project
~- [ ] I have pinned all new external dependencies to an exact version~
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
